### PR TITLE
refactor(*): updates wrapper with new changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,7 @@ Before calling the API methods, you need to create an instance of the `IncogniaA
 ```python3
 from incognia.api import IncogniaAPI
 
-# to use the US region
-api = IncogniaAPI('client-id', 'client-secret', 'us')
-
-# to use the BR region
-api = IncogniaAPI('client-id', 'client-secret', 'br')
+api = IncogniaAPI('client-id', 'client-secret')
 ```
 
 ### Incognia API
@@ -44,7 +40,7 @@ line or coordinates, returning a `dict`, containing the risk assessment and supp
 from incognia.api import IncogniaAPI
 from incognia.models import StructuredAddress, Coordinates
 
-api = IncogniaAPI('client-id', 'client-secret')  # us region is selected by default.
+api = IncogniaAPI('client-id', 'client-secret')
 
 # with structured address, a dict:
 structured_address: StructuredAddress = {
@@ -97,7 +93,7 @@ import datetime as dt
 from incognia.api import IncogniaAPI
 from incognia.feedback_events import FeedbackEvents  # feedbacks are strings.
 
-api = IncogniaAPI('client-id', 'client-secret')  # us region is selected by default.
+api = IncogniaAPI('client-id', 'client-secret')
 
 api.register_feedback(FeedbackEvents.SIGNUP_ACCEPTED, dt.datetime.now(),
                       installation_id='installation-id',

--- a/incognia/api.py
+++ b/incognia/api.py
@@ -7,7 +7,6 @@ import requests
 from .datetime_util import total_milliseconds_since_epoch
 from .endpoints import Endpoints
 from .exceptions import IncogniaHTTPError, IncogniaError
-from .feedback_events import FeedbackEventType
 from .json_util import encode
 from .models import Coordinates, StructuredAddress, TransactionAddress, PaymentValue, PaymentMethod
 from .token_manager import TokenManager
@@ -64,7 +63,7 @@ class IncogniaAPI:
             raise IncogniaHTTPError(e) from None
 
     def register_feedback(self,
-                          event: FeedbackEventType,
+                          event: str,
                           timestamp: dt.datetime,
                           external_id: Optional[str] = None,
                           login_id: Optional[str] = None,

--- a/incognia/api.py
+++ b/incognia/api.py
@@ -1,6 +1,6 @@
 import datetime as dt
 import json
-from typing import Final, Optional, List, Literal
+from typing import Final, Optional, List
 
 import requests
 
@@ -16,9 +16,8 @@ from .token_manager import TokenManager
 class IncogniaAPI:
     JSON_CONTENT_HEADER: Final[dict] = {'Content-type': 'application/json'}
 
-    def __init__(self, client_id: str, client_secret: str, region: Literal['br', 'us'] = 'us'):
-        self.__endpoints = Endpoints(region)
-        self.__token_manager = TokenManager(client_id, client_secret, self.__endpoints)
+    def __init__(self, client_id: str, client_secret: str):
+        self.__token_manager = TokenManager(client_id, client_secret)
 
     def __get_authorization_header(self) -> dict:
         access_token, token_type = self.__token_manager.get()
@@ -42,7 +41,7 @@ class IncogniaAPI:
                 'address_coordinates': address_coordinates
             }
             data = encode(body)
-            response = requests.post(self.__endpoints.signups, headers=headers, data=data)
+            response = requests.post(Endpoints.SIGNUPS, headers=headers, data=data)
             response.raise_for_status()
 
             return json.loads(response.content.decode('utf-8'))
@@ -56,7 +55,7 @@ class IncogniaAPI:
 
         try:
             headers = self.__get_authorization_header()
-            response = requests.get(f'{self.__endpoints.signups}/{signup_id}', headers=headers)
+            response = requests.get(f'{Endpoints.SIGNUPS}/{signup_id}', headers=headers)
             response.raise_for_status()
 
             return json.loads(response.content.decode('utf-8'))
@@ -92,7 +91,7 @@ class IncogniaAPI:
                 'installation_id': installation_id
             }
             data = encode(body)
-            response = requests.post(self.__endpoints.feedbacks, headers=headers, data=data)
+            response = requests.post(Endpoints.FEEDBACKS, headers=headers, data=data)
             response.raise_for_status()
 
         except requests.HTTPError as e:
@@ -123,7 +122,7 @@ class IncogniaAPI:
                 'payment_methods': payment_methods
             }
             data = encode(body)
-            response = requests.post(self.__endpoints.transactions, headers=headers, data=data)
+            response = requests.post(Endpoints.TRANSACTIONS, headers=headers, data=data)
             response.raise_for_status()
 
             return json.loads(response.content.decode('utf-8'))
@@ -150,7 +149,7 @@ class IncogniaAPI:
                 'external_id': external_id,
             }
             data = encode(body)
-            response = requests.post(self.__endpoints.transactions, headers=headers, data=data)
+            response = requests.post(Endpoints.TRANSACTIONS, headers=headers, data=data)
             response.raise_for_status()
 
             return json.loads(response.content.decode('utf-8'))

--- a/incognia/api.py
+++ b/incognia/api.py
@@ -102,7 +102,8 @@ class IncogniaAPI:
                          external_id: Optional[str] = None,
                          addresses: Optional[List[TransactionAddress]] = None,
                          payment_value: Optional[PaymentValue] = None,
-                         payment_methods: Optional[List[PaymentMethod]] = None) -> dict:
+                         payment_methods: Optional[List[PaymentMethod]] = None,
+                         evaluate: Optional[bool] = None) -> dict:
         if not installation_id:
             raise IncogniaError('installation_id is required.')
         if not account_id:
@@ -111,6 +112,7 @@ class IncogniaAPI:
         try:
             headers = self.__get_authorization_header()
             headers.update(self.JSON_CONTENT_HEADER)
+            params = None if evaluate is None else {'eval': evaluate}
             body = {
                 'type': 'payment',
                 'installation_id': installation_id,
@@ -121,7 +123,8 @@ class IncogniaAPI:
                 'payment_methods': payment_methods
             }
             data = encode(body)
-            response = requests.post(Endpoints.TRANSACTIONS, headers=headers, data=data)
+            response = requests.post(Endpoints.TRANSACTIONS, headers=headers, params=params,
+                                     data=data)
             response.raise_for_status()
 
             return json.loads(response.content.decode('utf-8'))
@@ -132,7 +135,8 @@ class IncogniaAPI:
     def register_login(self,
                        installation_id: str,
                        account_id: str,
-                       external_id: Optional[str] = None) -> dict:
+                       external_id: Optional[str] = None,
+                       evaluate: Optional[bool] = None) -> dict:
         if not installation_id:
             raise IncogniaError('installation_id is required.')
         if not account_id:
@@ -141,14 +145,16 @@ class IncogniaAPI:
         try:
             headers = self.__get_authorization_header()
             headers.update(self.JSON_CONTENT_HEADER)
+            params = None if evaluate is None else {'eval': evaluate}
             body = {
                 'type': 'login',
                 'installation_id': installation_id,
                 'account_id': account_id,
-                'external_id': external_id,
+                'external_id': external_id
             }
             data = encode(body)
-            response = requests.post(Endpoints.TRANSACTIONS, headers=headers, data=data)
+            response = requests.post(Endpoints.TRANSACTIONS, headers=headers, params=params,
+                                     data=data)
             response.raise_for_status()
 
             return json.loads(response.content.decode('utf-8'))

--- a/incognia/endpoints.py
+++ b/incognia/endpoints.py
@@ -1,11 +1,10 @@
-from typing import Final, Literal
+from typing import Final
 
 
 class Endpoints:
-    def __init__(self, region: Literal['br', 'us']):
-        self.base: Final[str] = f'https://api.{region}.incognia.com'
+    BASE: Final[str] = 'https://api.incognia.com'
 
-        self.token: Final[str] = f'{self.base}/api/v1/token'
-        self.signups: Final[str] = f'{self.base}/api/v2/onboarding/signups'
-        self.feedbacks: Final[str] = f'{self.base}/api/v2/feedbacks'
-        self.transactions: Final[str] = f'{self.base}/api/v2/authentication/transactions'
+    TOKEN: Final[str] = f'{BASE}/api/v1/token'
+    SIGNUPS: Final[str] = f'{BASE}/api/v2/onboarding/signups'
+    FEEDBACKS: Final[str] = f'{BASE}/api/v2/feedbacks'
+    TRANSACTIONS: Final[str] = f'{BASE}/api/v2/authentication/transactions'

--- a/incognia/endpoints.py
+++ b/incognia/endpoints.py
@@ -4,7 +4,7 @@ from typing import Final
 class Endpoints:
     BASE: Final[str] = 'https://api.incognia.com'
 
-    TOKEN: Final[str] = f'{BASE}/api/v1/token'
+    TOKEN: Final[str] = f'{BASE}/api/v2/token'
     SIGNUPS: Final[str] = f'{BASE}/api/v2/onboarding/signups'
     FEEDBACKS: Final[str] = f'{BASE}/api/v2/feedbacks'
     TRANSACTIONS: Final[str] = f'{BASE}/api/v2/authentication/transactions'

--- a/incognia/feedback_events.py
+++ b/incognia/feedback_events.py
@@ -1,24 +1,23 @@
 from typing import Final
 
-FeedbackEventType = str
-
 
 class FeedbackEvents:
-    SIGNUP_ACCEPTED: Final[FeedbackEventType] = 'signup_accepted'
-    SIGNUP_DECLINED: Final[FeedbackEventType] = 'signup_declined'
-    PAYMENT_ACCEPTED: Final[FeedbackEventType] = 'payment_accepted'
-    PAYMENT_ACCEPTED_BY_THIRD_PARTY: Final[FeedbackEventType] = 'payment_accepted_by_third_party'
-    PAYMENT_DECLINED: Final[FeedbackEventType] = 'payment_declined'
-    PAYMENT_DECLINED_BY_RISK_ANALYSIS: Final[FeedbackEventType] = \
+    SIGNUP_ACCEPTED: Final[str] = 'signup_accepted'
+    SIGNUP_DECLINED: Final[str] = 'signup_declined'
+    PAYMENT_ACCEPTED: Final[str] = 'payment_accepted'
+    PAYMENT_ACCEPTED_BY_THIRD_PARTY: Final[str] = 'payment_accepted_by_third_party'
+    PAYMENT_DECLINED: Final[str] = 'payment_declined'
+    PAYMENT_DECLINED_BY_RISK_ANALYSIS: Final[str] = \
         'payment_declined_by_risk_analysis'
-    PAYMENT_DECLINED_BY_MANUAL_REVIEW: Final[FeedbackEventType] = \
+    PAYMENT_DECLINED_BY_MANUAL_REVIEW: Final[str] = \
         'payment_declined_by_manual_review'
-    PAYMENT_DECLINED_BY_BUSINESS: Final[FeedbackEventType] = 'payment_declined_by_business'
-    PAYMENT_DECLINED_BY_ACQUIRER: Final[FeedbackEventType] = 'payment_declined_by_acquirer'
-    LOGIN_ACCEPTED: Final[FeedbackEventType] = 'login_accepted'
-    LOGIN_DECLINED: Final[FeedbackEventType] = 'login_declined'
-    VERIFIED: Final[FeedbackEventType] = 'verified'
-    IDENTITY_FRAUD: Final[FeedbackEventType] = 'identity_fraud'
-    ACCOUNT_TAKEOVER: Final[FeedbackEventType] = 'account_takeover'
-    CHARGEBACK: Final[FeedbackEventType] = 'chargeback'
-    MPOS_FRAUD: Final[FeedbackEventType] = 'mpos_fraud'
+    PAYMENT_DECLINED_BY_BUSINESS: Final[str] = 'payment_declined_by_business'
+    PAYMENT_DECLINED_BY_ACQUIRER: Final[str] = 'payment_declined_by_acquirer'
+    LOGIN_ACCEPTED: Final[str] = 'login_accepted'
+    LOGIN_DECLINED: Final[str] = 'login_declined'
+    VERIFIED: Final[str] = 'verified'
+    IDENTITY_FRAUD: Final[str] = 'identity_fraud'
+    ACCOUNT_TAKEOVER: Final[str] = 'account_takeover'
+    CHARGEBACK_NOTIFICATION: Final[str] = 'chargeback_notification'
+    CHARGEBACK: Final[str] = 'chargeback'
+    MPOS_FRAUD: Final[str] = 'mpos_fraud'

--- a/incognia/feedback_events.py
+++ b/incognia/feedback_events.py
@@ -22,3 +22,8 @@ class FeedbackEvents:
     CHARGEBACK_NOTIFICATION: Final[str] = 'chargeback_notification'
     CHARGEBACK: Final[str] = 'chargeback'
     MPOS_FRAUD: Final[str] = 'mpos_fraud'
+    CHALLENGE_PASSED: Final[str] = 'challenge_passed'
+    CHALLENGE_FAILED: Final[str] = 'challenge_failed'
+    PASSWORD_CHANGED_SUCCESSFULLY: Final[str] = 'password_changed_successfully'
+    PASSWORD_CHANGE_FAILED: Final[str] = 'password_change_failed'
+    PROMOTION_ABUSE: Final[str] = 'promotion_abuse'

--- a/incognia/feedback_events.py
+++ b/incognia/feedback_events.py
@@ -6,6 +6,7 @@ class FeedbackEvents:
     SIGNUP_DECLINED: Final[str] = 'signup_declined'
     PAYMENT_ACCEPTED: Final[str] = 'payment_accepted'
     PAYMENT_ACCEPTED_BY_THIRD_PARTY: Final[str] = 'payment_accepted_by_third_party'
+    PAYMENT_ACCEPTED_BY_CONTROL_GROUP: Final[str] = 'payment_accepted_by_control_group'
     PAYMENT_DECLINED: Final[str] = 'payment_declined'
     PAYMENT_DECLINED_BY_RISK_ANALYSIS: Final[str] = \
         'payment_declined_by_risk_analysis'

--- a/incognia/token_manager.py
+++ b/incognia/token_manager.py
@@ -17,10 +17,9 @@ class TokenValues(NamedTuple):
 class TokenManager:
     TOKEN_REFRESH_BEFORE_SECONDS: Final[int] = 10
 
-    def __init__(self, client_id: str, client_secret: str, endpoints: Endpoints):
+    def __init__(self, client_id: str, client_secret: str):
         self.__client_id: str = client_id
         self.__client_secret: str = client_secret
-        self.__endpoints: Endpoints = endpoints
         self.__token_values: Optional[TokenValues] = None
         self.__expiration_time: Optional[dt.datetime] = None
 
@@ -31,7 +30,7 @@ class TokenManager:
         headers = {'Authorization': f'Basic {client_id_and_secret_encoded}'}
 
         try:
-            response = requests.post(url=self.__endpoints.token, headers=headers,
+            response = requests.post(url=Endpoints.TOKEN, headers=headers,
                                      auth=(client_id, client_secret))
             response.raise_for_status()
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r', encoding='utf-8') as f:
 
 setup(
     name='incognia-python',
-    version='1.1.0',
+    version='1.2.0',
     packages=find_packages(exclude=['tests']),
     license='MIT',
     url='https://github.com/inloco/incognia-python',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -56,6 +56,7 @@ class TestIncogniaAPI(TestCase):
         '{"type": "login",' \
         f' "installation_id": "{INVALID_INSTALLATION_ID}",' \
         f' "account_id": "{INVALID_ACCOUNT_ID}"}}'.encode('utf-8')
+    DEFAULT_PARAMS: Final[None] = None
 
     @patch('requests.post')
     @patch.object(TokenManager, 'get', return_value=TOKEN_VALUES)
@@ -258,6 +259,7 @@ class TestIncogniaAPI(TestCase):
         mock_token_manager_get.assert_called()
         mock_requests_post.assert_called_with(Endpoints.TRANSACTIONS,
                                               headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
+                                              params=self.DEFAULT_PARAMS,
                                               data=self.REGISTER_VALID_PAYMENT_DATA)
 
         self.assertEqual(request_response, json.loads(self.JSON_RESPONSE.decode('utf-8')))
@@ -312,6 +314,7 @@ class TestIncogniaAPI(TestCase):
         mock_token_manager_get.assert_called()
         mock_requests_post.assert_called_with(Endpoints.TRANSACTIONS,
                                               headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
+                                              params=self.DEFAULT_PARAMS,
                                               data=self.REGISTER_INVALID_PAYMENT_DATA)
 
     @patch('requests.post')
@@ -334,6 +337,7 @@ class TestIncogniaAPI(TestCase):
         mock_token_manager_get.assert_called()
         mock_requests_post.assert_called_with(Endpoints.TRANSACTIONS,
                                               headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
+                                              params=self.DEFAULT_PARAMS,
                                               data=self.REGISTER_VALID_LOGIN_DATA)
 
         self.assertEqual(request_response, json.loads(self.JSON_RESPONSE.decode('utf-8')))
@@ -388,4 +392,5 @@ class TestIncogniaAPI(TestCase):
         mock_token_manager_get.assert_called()
         mock_requests_post.assert_called_with(Endpoints.TRANSACTIONS,
                                               headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
+                                              params=self.DEFAULT_PARAMS,
                                               data=self.REGISTER_INVALID_LOGIN_DATA)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,6 @@ import requests
 from incognia.api import IncogniaAPI
 from incognia.endpoints import Endpoints
 from incognia.exceptions import IncogniaHTTPError, IncogniaError
-from incognia.feedback_events import FeedbackEventType
 from incognia.token_manager import TokenValues, TokenManager
 
 
@@ -36,8 +35,8 @@ class TestIncogniaAPI(TestCase):
         .encode('utf-8')
     OK_STATUS_CODE: Final[int] = 200
     CLIENT_ERROR_CODE: Final[int] = 400
-    VALID_EVENT_FEEDBACK_TYPE: Final[FeedbackEventType] = 'valid_event_feedback_type'
-    INVALID_EVENT_FEEDBACK_TYPE: Final[FeedbackEventType] = 'invalid_event_feedback_type'
+    VALID_EVENT_FEEDBACK_TYPE: Final[str] = 'valid_event_feedback_type'
+    INVALID_EVENT_FEEDBACK_TYPE: Final[str] = 'invalid_event_feedback_type'
     TIMESTAMP: Final[dt.datetime] = dt.datetime.utcfromtimestamp(0)
     REGISTER_VALID_FEEDBACK_DATA: Final[ascii] = f'{{"event": "{VALID_EVENT_FEEDBACK_TYPE}",' \
                                                  f' "timestamp": 0}}'.encode('utf-8')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -57,7 +57,6 @@ class TestIncogniaAPI(TestCase):
         '{"type": "login",' \
         f' "installation_id": "{INVALID_INSTALLATION_ID}",' \
         f' "account_id": "{INVALID_ACCOUNT_ID}"}}'.encode('utf-8')
-    ENDPOINTS: Final[Endpoints] = Endpoints('us')
 
     @patch('requests.post')
     @patch.object(TokenManager, 'get', return_value=TOKEN_VALUES)
@@ -76,7 +75,7 @@ class TestIncogniaAPI(TestCase):
         request_response = api.register_new_signup(installation_id=self.INSTALLATION_ID)
 
         mock_token_manager_get.assert_called()
-        mock_requests_post.assert_called_with(self.ENDPOINTS.signups,
+        mock_requests_post.assert_called_with(Endpoints.SIGNUPS,
                                               headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
                                               data=self.REGISTER_SIGNUP_DATA)
 
@@ -100,7 +99,7 @@ class TestIncogniaAPI(TestCase):
         self.assertRaises(IncogniaHTTPError, api.register_new_signup, self.INSTALLATION_ID)
 
         mock_token_manager_get.assert_called()
-        mock_requests_post.assert_called_with(self.ENDPOINTS.signups,
+        mock_requests_post.assert_called_with(Endpoints.SIGNUPS,
                                               headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
                                               data=self.REGISTER_SIGNUP_DATA)
 
@@ -134,7 +133,7 @@ class TestIncogniaAPI(TestCase):
         request_response = api.get_signup_assessment(signup_id=self.SIGNUP_ID)
 
         mock_token_manager_get.assert_called()
-        mock_requests_get.assert_called_with(f'{self.ENDPOINTS.signups}/{self.SIGNUP_ID}',
+        mock_requests_get.assert_called_with(f'{Endpoints.SIGNUPS}/{self.SIGNUP_ID}',
                                              headers=self.AUTH_HEADER)
 
         self.assertEqual(request_response, json.loads(self.JSON_RESPONSE.decode('utf-8')))
@@ -157,7 +156,7 @@ class TestIncogniaAPI(TestCase):
         self.assertRaises(IncogniaHTTPError, api.get_signup_assessment, self.SIGNUP_ID)
 
         mock_token_manager_get.assert_called()
-        mock_requests_get.assert_called_with(f'{self.ENDPOINTS.signups}/{self.SIGNUP_ID}',
+        mock_requests_get.assert_called_with(f'{Endpoints.SIGNUPS}/{self.SIGNUP_ID}',
                                              headers=self.AUTH_HEADER)
 
     @patch('requests.get')
@@ -184,7 +183,7 @@ class TestIncogniaAPI(TestCase):
         api.register_feedback(self.VALID_EVENT_FEEDBACK_TYPE, self.TIMESTAMP)
 
         mock_token_manager_get.assert_called()
-        mock_requests_post.assert_called_with(self.ENDPOINTS.feedbacks,
+        mock_requests_post.assert_called_with(Endpoints.FEEDBACKS,
                                               headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
                                               data=self.REGISTER_VALID_FEEDBACK_DATA)
 
@@ -236,7 +235,7 @@ class TestIncogniaAPI(TestCase):
                           timestamp=self.TIMESTAMP)
 
         mock_token_manager_get.assert_called()
-        mock_requests_post.assert_called_with(self.ENDPOINTS.feedbacks,
+        mock_requests_post.assert_called_with(Endpoints.FEEDBACKS,
                                               headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
                                               data=self.REGISTER_INVALID_FEEDBACK_DATA)
 
@@ -258,7 +257,7 @@ class TestIncogniaAPI(TestCase):
         request_response = api.register_payment(self.INSTALLATION_ID, self.ACCOUNT_ID)
 
         mock_token_manager_get.assert_called()
-        mock_requests_post.assert_called_with(self.ENDPOINTS.transactions,
+        mock_requests_post.assert_called_with(Endpoints.TRANSACTIONS,
                                               headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
                                               data=self.REGISTER_VALID_PAYMENT_DATA)
 
@@ -312,7 +311,7 @@ class TestIncogniaAPI(TestCase):
                           account_id=self.INVALID_ACCOUNT_ID)
 
         mock_token_manager_get.assert_called()
-        mock_requests_post.assert_called_with(self.ENDPOINTS.transactions,
+        mock_requests_post.assert_called_with(Endpoints.TRANSACTIONS,
                                               headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
                                               data=self.REGISTER_INVALID_PAYMENT_DATA)
 
@@ -334,7 +333,7 @@ class TestIncogniaAPI(TestCase):
         request_response = api.register_login(self.INSTALLATION_ID, self.ACCOUNT_ID)
 
         mock_token_manager_get.assert_called()
-        mock_requests_post.assert_called_with(self.ENDPOINTS.transactions,
+        mock_requests_post.assert_called_with(Endpoints.TRANSACTIONS,
                                               headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
                                               data=self.REGISTER_VALID_LOGIN_DATA)
 
@@ -388,6 +387,6 @@ class TestIncogniaAPI(TestCase):
                           account_id=self.INVALID_ACCOUNT_ID)
 
         mock_token_manager_get.assert_called()
-        mock_requests_post.assert_called_with(self.ENDPOINTS.transactions,
+        mock_requests_post.assert_called_with(Endpoints.TRANSACTIONS,
                                               headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
                                               data=self.REGISTER_INVALID_LOGIN_DATA)

--- a/tests/test_token_manager.py
+++ b/tests/test_token_manager.py
@@ -26,7 +26,6 @@ class TestTokenManager(TestCase):
     HEADERS: Final[dict] = {'Authorization': f'Basic {CLIENT_ID_AND_SECRET_ENCODED}'}
     OK_STATUS_CODE: Final[int] = 200
     CLIENT_ERROR_CODE: Final[int] = 400
-    ENDPOINTS: Final[Endpoints] = Endpoints('us')
 
     @patch('requests.post')
     def test_get_when_credentials_are_valid_should_return_a_valid_token(self,
@@ -38,9 +37,9 @@ class TestTokenManager(TestCase):
 
         mock_requests_post.configure_mock(return_value=get_mocked_response())
 
-        token_manager = TokenManager(self.CLIENT_ID, self.CLIENT_SECRET, self.ENDPOINTS)
+        token_manager = TokenManager(self.CLIENT_ID, self.CLIENT_SECRET)
         token_values = token_manager.get()
-        mock_requests_post.assert_called_with(url=self.ENDPOINTS.token, headers=self.HEADERS,
+        mock_requests_post.assert_called_with(url=Endpoints.TOKEN, headers=self.HEADERS,
                                               auth=(self.CLIENT_ID, self.CLIENT_SECRET))
         self.assertEqual(token_values, self.TOKEN_VALUES)
 
@@ -55,16 +54,16 @@ class TestTokenManager(TestCase):
 
         mock_requests_post.configure_mock(return_value=get_mocked_response())
 
-        token_manager = TokenManager(self.CLIENT_ID, self.CLIENT_SECRET, self.ENDPOINTS)
+        token_manager = TokenManager(self.CLIENT_ID, self.CLIENT_SECRET)
         self.assertRaises(IncogniaHTTPError, token_manager.get)
-        mock_requests_post.assert_called_with(url=self.ENDPOINTS.token, headers=self.HEADERS,
+        mock_requests_post.assert_called_with(url=Endpoints.TOKEN, headers=self.HEADERS,
                                               auth=(self.CLIENT_ID, self.CLIENT_SECRET))
 
     @patch('requests.post')
     def test_get_when_token_is_expired_should_return_a_new_valid_token(self,
                                                                        mock_requests_post:
                                                                        Mock):
-        token_manager = TokenManager(self.CLIENT_ID, self.CLIENT_SECRET, self.ENDPOINTS)
+        token_manager = TokenManager(self.CLIENT_ID, self.CLIENT_SECRET)
 
         def get_first_mocked_response() -> requests.Response:
             response = requests.Response()
@@ -76,7 +75,7 @@ class TestTokenManager(TestCase):
 
         first_token_values = token_manager.get()
 
-        mock_requests_post.assert_called_with(url=self.ENDPOINTS.token, headers=self.HEADERS,
+        mock_requests_post.assert_called_with(url=Endpoints.TOKEN, headers=self.HEADERS,
                                               auth=(self.CLIENT_ID, self.CLIENT_SECRET))
 
         def get_second_mocked_response() -> requests.Response:
@@ -89,7 +88,7 @@ class TestTokenManager(TestCase):
 
         second_token_values = token_manager.get()
 
-        mock_requests_post.assert_called_with(url=self.ENDPOINTS.token, headers=self.HEADERS,
+        mock_requests_post.assert_called_with(url=Endpoints.TOKEN, headers=self.HEADERS,
                                               auth=(self.CLIENT_ID, self.CLIENT_SECRET))
 
         self.assertEqual(first_token_values, self.SHORT_EXPIRATION_TOKEN_VALUES)


### PR DESCRIPTION
- [X] Removes region selection (base endpoint is fixed: `https://api.incognia.com`);
- [X] Adds missing event types:
  1 - `chargeback_notification`;
  2 - `payment_accepted_by_control_group`; 
- [X] Updates token route for v2;

Fields response are always updates since it's a dictionary;