### PR TITLE
feat(sign-up): Add new optional params for sign-up flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ coordinates: Coordinates = {
     'lng': -73.98509720487937
 }
 assessment: dict = api.register_new_signup('installation-id', address_coordinates=coordinates)
+
+# with external_id:
+external_id: str = 'external-id'
+assessment: dict = api.register_new_signup('installation-id', external_id=external_id)
+
+# with policy_id:
+policy_id: str = 'policy-id'
+assessment: dict = api.register_new_signup('installation-id', policy_id=policy_id)
+
+# with account_id:
+account_id: str = 'account-id'
+assessment: dict = api.register_new_signup('installation-id', account_id=account_id)
+
 ```
 
 #### Getting a Signup

--- a/incognia/api.py
+++ b/incognia/api.py
@@ -23,7 +23,10 @@ class IncogniaAPI:
                             installation_id: str,
                             address_line: Optional[str] = None,
                             structured_address: Optional[StructuredAddress] = None,
-                            address_coordinates: Optional[Coordinates] = None) -> dict:
+                            address_coordinates: Optional[Coordinates] = None,
+                            external_id: Optional[str] = None,
+                            policy_id: Optional[str] = None,
+                            account_id: Optional[str] = None) -> dict:
         if not installation_id:
             raise IncogniaError('installation_id is required.')
 
@@ -34,7 +37,10 @@ class IncogniaAPI:
                 'installation_id': installation_id,
                 'address_line': address_line,
                 'structured_address': structured_address,
-                'address_coordinates': address_coordinates
+                'address_coordinates': address_coordinates,
+                'external_id': external_id,
+                'policy_id': policy_id,
+                'account_id': account_id
             }
             data = encode(body)
             return self.__request.post(Endpoints.SIGNUPS, headers=headers, data=data)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,6 +18,26 @@ class TestIncogniaAPI(TestCase):
     INVALID_INSTALLATION_ID: Final[str] = 'INVALID_INSTALLATION_ID'
     ACCOUNT_ID: Final[str] = 'ANY_ACCOUNT_ID'
     INVALID_ACCOUNT_ID: Final[str] = 'INVALID_ACCOUNT_ID'
+    ADDRESS_LINE: Final[str] = 'ANY_ADDRESS_LINE'
+    STRUCTURED_ADDRESS: Final[dict] = {
+        'locale': 'ANY_LOCALE',
+        'country_name': 'ANY_COUNTRY_NAME',
+        'country_code': 'ANY_COUNTRY_CODE',
+        'state': 'ANY_STATE',
+        'city': 'ANY_CITY',
+        'borough': 'ANY_BOROUGH',
+        'neighborhood': 'ANY_NEIGHBORHOOD',
+        'street': 'ANY_STREET',
+        'number': 'ANY_NUMBER',
+        'complements': 'ANY_COMPLEMENTS',
+        'postal_code': 'ANY_POSTAL_CODE'
+    }
+    ADDRESS_COORDINATES: Final[dict] = {
+        'lat': 1.69,
+        'lng': 2.345
+    }
+    EXTERNAL_ID: Final[str] = 'ANY_EXTERNAL_ID'
+    POLICY_ID: Final[str] = 'ANY_POLICY_ID'
     SIGNUP_ID: Final[str] = 'ANY_SIGNUP_ID'
     TOKEN_VALUES: Final[TokenValues] = TokenValues('ACCESS_TOKEN', 'TOKEN_TYPE')
     JSON_RESPONSE: Final[dict] = {
@@ -35,6 +55,15 @@ class TestIncogniaAPI(TestCase):
     }
     REGISTER_SIGNUP_DATA: Final[bytes] = encode({
         'installation_id': f'{INSTALLATION_ID}'
+    })
+    FULL_REGISTER_SIGNUP_DATA: Final[bytes] = encode({
+        'installation_id': f'{INSTALLATION_ID}',
+        'address_line': f'{ADDRESS_LINE}',
+        'structured_address': STRUCTURED_ADDRESS,
+        'address_coordinates': ADDRESS_COORDINATES,
+        'external_id': f'{EXTERNAL_ID}',
+        'policy_id': f'{POLICY_ID}',
+        'account_id': f'{ACCOUNT_ID}'
     })
     OK_STATUS_CODE: Final[int] = 200
     CLIENT_ERROR_CODE: Final[int] = 400
@@ -84,6 +113,28 @@ class TestIncogniaAPI(TestCase):
         mock_base_request_post.assert_called_with(Endpoints.SIGNUPS,
                                                   headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
                                                   data=self.REGISTER_SIGNUP_DATA)
+
+        self.assertEqual(response, self.JSON_RESPONSE)
+
+    @patch.object(BaseRequest, 'post')
+    @patch.object(TokenManager, 'get', return_value=TOKEN_VALUES)
+    def test_register_new_signup_when_installation_id_is_valid_should_return_full_valid_dict_(
+            self, mock_token_manager_get: Mock, mock_base_request_post: Mock):
+        mock_base_request_post.configure_mock(return_value=self.JSON_RESPONSE)
+
+        api = IncogniaAPI(self.CLIENT_ID, self.CLIENT_SECRET)
+        response = api.register_new_signup(installation_id=self.INSTALLATION_ID,
+                                           address_line=self.ADDRESS_LINE,
+                                           structured_address=self.STRUCTURED_ADDRESS,
+                                           address_coordinates=self.ADDRESS_COORDINATES,
+                                           external_id=self.EXTERNAL_ID,
+                                           policy_id=self.POLICY_ID,
+                                           account_id=self.ACCOUNT_ID)
+
+        mock_token_manager_get.assert_called()
+        mock_base_request_post.assert_called_with(Endpoints.SIGNUPS,
+                                                  headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
+                                                  data=self.FULL_REGISTER_SIGNUP_DATA)
 
         self.assertEqual(response, self.JSON_RESPONSE)
 


### PR DESCRIPTION
Accept `external_id`, `policy_id`, and `account_id` as optional params on the `sign-up` flow.