### PR TITLE
Add register_web_login method in order to support session_token requests

### DIFF
--- a/incognia/api.py
+++ b/incognia/api.py
@@ -153,3 +153,30 @@ class IncogniaAPI:
 
         except IncogniaHTTPError as e:
             raise IncogniaHTTPError(e) from None
+
+    def register_web_login(self,
+                       session_token: str,
+                       account_id: str,
+                       external_id: Optional[str] = None,
+                       evaluate: Optional[bool] = None) -> dict:
+        if not session_token:
+            raise IncogniaError('session_token is required.')
+        if not account_id:
+            raise IncogniaError('account_id is required.')
+
+        try:
+            headers = self.__get_authorization_header()
+            headers.update(JSON_CONTENT_HEADER)
+            params = None if evaluate is None else {'eval': evaluate}
+            body = {
+                'type': 'login',
+                'session_token': session_token,
+                'account_id': account_id,
+                'external_id': external_id
+            }
+            data = encode(body)
+            return self.__request.post(Endpoints.TRANSACTIONS, headers=headers, params=params,
+                                       data=data)
+
+        except IncogniaHTTPError as e:
+            raise IncogniaHTTPError(e) from None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,7 +15,9 @@ class TestIncogniaAPI(TestCase):
     CLIENT_ID: Final[str] = 'ANY_ID'
     CLIENT_SECRET: Final[str] = 'ANY_SECRET'
     INSTALLATION_ID: Final[str] = 'ANY_INSTALLATION_ID'
+    SESSION_TOKEN: Final[str] = 'ANY_SESSION_TOKEN'
     INVALID_INSTALLATION_ID: Final[str] = 'INVALID_INSTALLATION_ID'
+    INVALID_SESSION_TOKEN: Final[str] = 'INVALID_SESSION_TOKEN'
     ACCOUNT_ID: Final[str] = 'ANY_ACCOUNT_ID'
     INVALID_ACCOUNT_ID: Final[str] = 'INVALID_ACCOUNT_ID'
     ADDRESS_LINE: Final[str] = 'ANY_ADDRESS_LINE'
@@ -93,9 +95,19 @@ class TestIncogniaAPI(TestCase):
         'installation_id': f'{INSTALLATION_ID}',
         'account_id': f'{ACCOUNT_ID}'
     })
+    REGISTER_VALID_WEB_LOGIN_DATA: Final[bytes] = encode({
+        'type': 'login',
+        'session_token': f'{SESSION_TOKEN}',
+        'account_id': f'{ACCOUNT_ID}'
+    })
     REGISTER_INVALID_LOGIN_DATA: Final[bytes] = encode({
         'type': 'login',
         'installation_id': f'{INVALID_INSTALLATION_ID}',
+        'account_id': f'{INVALID_ACCOUNT_ID}'
+    })
+    REGISTER_INVALID_WEB_LOGIN_DATA: Final[bytes] = encode({
+        'type': 'login',
+        'session_token': f'{INVALID_SESSION_TOKEN}',
         'account_id': f'{INVALID_ACCOUNT_ID}'
     })
     DEFAULT_PARAMS: Final[None] = None
@@ -369,6 +381,70 @@ class TestIncogniaAPI(TestCase):
 
         self.assertRaises(IncogniaHTTPError, api.register_login,
                           installation_id=self.INVALID_INSTALLATION_ID,
+                          account_id=self.INVALID_ACCOUNT_ID)
+
+        mock_token_manager_get.assert_called()
+        mock_base_request_post.assert_called_with(Endpoints.TRANSACTIONS,
+                                                  headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
+                                                  params=self.DEFAULT_PARAMS,
+                                                  data=self.REGISTER_INVALID_LOGIN_DATA)
+
+
+    @patch.object(BaseRequest, 'post')
+    @patch.object(TokenManager, 'get', return_value=TOKEN_VALUES)
+    def test_register_web_login_when_required_fields_are_valid_should_work(
+            self, mock_token_manager_get: Mock, mock_base_request_post: Mock):
+        mock_base_request_post.configure_mock(return_value=self.JSON_RESPONSE)
+
+        api = IncogniaAPI(self.CLIENT_ID, self.CLIENT_SECRET)
+
+        request_response = api.register_web_login(self.SESSION_TOKEN, self.ACCOUNT_ID)
+
+        mock_token_manager_get.assert_called()
+        mock_base_request_post.assert_called_with(Endpoints.TRANSACTIONS,
+                                                  headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
+                                                  params=self.DEFAULT_PARAMS,
+                                                  data=self.REGISTER_VALID_LOGIN_DATA)
+
+        self.assertEqual(request_response, self.JSON_RESPONSE)
+
+
+    @patch.object(BaseRequest, 'post')
+    @patch.object(TokenManager, 'get', return_value=TOKEN_VALUES)
+    def test_register_web_login_when_session_token_is_empty_should_raise_an_IncogniaError(
+            self, mock_token_manager_get: Mock, mock_base_request_post: Mock):
+        api = IncogniaAPI(self.CLIENT_ID, self.CLIENT_SECRET)
+
+        self.assertRaises(IncogniaError, api.register_web_login, session_token='',
+                          account_id=self.ACCOUNT_ID)
+
+        mock_token_manager_get.assert_not_called()
+        mock_base_request_post.assert_not_called()
+
+
+    @patch.object(BaseRequest, 'post')
+    @patch.object(TokenManager, 'get', return_value=TOKEN_VALUES)
+    def test_register_web_login_when_account_id_is_empty_should_raise_an_IncogniaError(
+            self, mock_token_manager_get: Mock, mock_base_request_post: Mock):
+        api = IncogniaAPI(self.CLIENT_ID, self.CLIENT_SECRET)
+
+        self.assertRaises(IncogniaError, api.register_web_login, session_token=self.SESSION_TOKEN,
+                          account_id='')
+
+        mock_token_manager_get.assert_not_called()
+        mock_base_request_post.assert_not_called()
+
+
+    @patch.object(BaseRequest, 'post')
+    @patch.object(TokenManager, 'get', return_value=TOKEN_VALUES)
+    def test_register_web_login_when_required_fields_are_invalid_should_raise_an_IncogniaHTTPError(
+            self, mock_token_manager_get: Mock, mock_base_request_post: Mock):
+        mock_base_request_post.configure_mock(side_effect=IncogniaHTTPError)
+
+        api = IncogniaAPI(self.CLIENT_ID, self.CLIENT_SECRET)
+
+        self.assertRaises(IncogniaHTTPError, api.register_web_login,
+                          session_token=self.INVALID_SESSION_TOKEN,
                           account_id=self.INVALID_ACCOUNT_ID)
 
         mock_token_manager_get.assert_called()


### PR DESCRIPTION
In order to avoid breaking existing integrations, I created a new method based on the existing register_login in order to support session_token requests using the Python lib.