### PR TITLE
feat: add missing fields to register_feedback

### DIFF
--- a/incognia/datetime_util.py
+++ b/incognia/datetime_util.py
@@ -2,4 +2,8 @@ import datetime as dt
 
 
 def total_milliseconds_since_epoch(t: dt.datetime) -> int:
-    return int((t - dt.datetime.utcfromtimestamp(0)).total_seconds() * 1000.0)
+    return int((t - dt.datetime.fromtimestamp(0, dt.timezone.utc)).total_seconds() * 1000.0)
+
+
+def has_timezone(d: dt.datetime) -> bool:
+    return d.tzinfo is not None and d.tzinfo.utcoffset(d) is not None


### PR DESCRIPTION
Adds missing fields for specified timestamps.

Because we need to transform these timestamps into RFC3339 strings, a validation of whether the datetime object has timezones was added. This validation followed this [spec](https://docs.python.org/3/library/datetime.html#determining-if-an-object-is-aware-or-naive).