### PR TITLE
Add a singleton metaclass for IncogniaAPI

### DIFF
--- a/.github/workflows/continuous.yaml
+++ b/.github/workflows/continuous.yaml
@@ -52,15 +52,15 @@ jobs:
       - name: Publish Python distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          skip_existing: true
-          print_hash: true
+          skip-existing: true
+          print-hash: true
           verbose: true
       - name: Publish Python distribution to PyPI
         if: startsWith(github.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-          print_hash: true
+          print-hash: true
           verbose: true

--- a/incognia/api.py
+++ b/incognia/api.py
@@ -6,11 +6,12 @@ from .endpoints import Endpoints
 from .exceptions import IncogniaHTTPError, IncogniaError
 from .json_util import encode
 from .models import Coordinates, StructuredAddress, TransactionAddress, PaymentValue, PaymentMethod
+from .singleton import Singleton
 from .token_manager import TokenManager
 from .base_request import BaseRequest, JSON_CONTENT_HEADER
 
 
-class IncogniaAPI:
+class IncogniaAPI(metaclass=Singleton):
     def __init__(self, client_id: str, client_secret: str):
         self.__token_manager = TokenManager(client_id, client_secret)
         self.__request = BaseRequest()

--- a/incognia/singleton.py
+++ b/incognia/singleton.py
@@ -1,0 +1,8 @@
+
+class Singleton(type):
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -136,6 +136,12 @@ class TestIncogniaAPI(TestCase):
     })
     DEFAULT_PARAMS: Final[None] = None
 
+    def test_metaclass_singleton_should_always_return_the_same_instance(self):
+        api1 = IncogniaAPI(self.CLIENT_ID, self.CLIENT_SECRET)
+        api2 = IncogniaAPI(self.CLIENT_ID, self.CLIENT_SECRET)
+
+        self.assertEqual(api1, api2)
+
     @patch.object(BaseRequest, 'post')
     @patch.object(TokenManager, 'get', return_value=TOKEN_VALUES)
     def test_register_new_signup_when_installation_id_is_valid_should_return_a_valid_dict(


### PR DESCRIPTION
This PR introduces the `Singleton` pattern to the `IncogniaAPI` class by defining the `Singleton` metaclass. The implementation ensures that all instances of the class share the same state, returning the same instance whenever the class is instantiated with the same parameters.

The main motivation for this change is to ensure that, when instantiating the `IncogniaAPI` multiple times with the same `client_id` and `client_secret`, the application uses the same authentication token instead of creating new tokens with each new instance.

