### PR TITLE
Feat: add location to transactions

### DIFF
--- a/incognia/api.py
+++ b/incognia/api.py
@@ -5,7 +5,14 @@ from .datetime_util import has_timezone, datetime_valid
 from .endpoints import Endpoints
 from .exceptions import IncogniaHTTPError, IncogniaError
 from .json_util import encode
-from .models import Coordinates, StructuredAddress, TransactionAddress, PaymentValue, PaymentMethod, Location
+from .models import (
+    Coordinates,
+    StructuredAddress,
+    TransactionAddress,
+    PaymentValue,
+    PaymentMethod,
+    Location,
+)
 from .singleton import Singleton
 from .token_manager import TokenManager
 from .base_request import BaseRequest, JSON_CONTENT_HEADER
@@ -109,9 +116,11 @@ class IncogniaAPI(metaclass=Singleton):
                 raise IncogniaError('location argument requires "latitude" field')
             if location['longitude'] is None:
                 raise IncogniaError('location argument requires "longitude" field')
-            if location['collected_at'] is not None and not datetime_valid(location['collected_at']):
+            if (
+                location['collected_at'] is not None
+                and not datetime_valid(location['collected_at'])
+            ):
                 raise IncogniaError('location["collected_at"] must conform to ISO-8601 format')
-
 
         try:
             headers = self.__get_authorization_header()
@@ -140,7 +149,7 @@ class IncogniaAPI(metaclass=Singleton):
                        account_id: str,
                        location: Optional[Location] = None,
                        external_id: Optional[str] = None,
-                       evaluate: Optional[bool] = None, # true?
+                       evaluate: Optional[bool] = None,
                        policy_id: Optional[str] = None) -> dict:
         if not request_token:
             raise IncogniaError('request_token is required.')
@@ -151,7 +160,10 @@ class IncogniaAPI(metaclass=Singleton):
                 raise IncogniaError('location argument requires "latitude" field')
             if location['longitude'] is None:
                 raise IncogniaError('location argument requires "longitude" field')
-            if location['collected_at'] is not None and not datetime_valid(location['collected_at']):
+            if (
+                location['collected_at'] is not None
+                and not datetime_valid(location['collected_at'])
+            ):
                 raise IncogniaError('location["collected_at"] must conform to ISO-8601 format')
 
         try:
@@ -162,7 +174,7 @@ class IncogniaAPI(metaclass=Singleton):
                 'type': 'login',
                 'request_token': request_token,
                 'account_id': account_id,
-                'location' : location,
+                'location': location,
                 'external_id': external_id,
                 'policy_id': policy_id
             }

--- a/incognia/datetime_util.py
+++ b/incognia/datetime_util.py
@@ -4,9 +4,10 @@ from datetime import datetime
 def has_timezone(d: datetime) -> bool:
     return d.tzinfo is not None and d.tzinfo.utcoffset(d) is not None
 
+
 def datetime_valid(dt_str):
     try:
         datetime.fromisoformat(dt_str.replace('Z', '+00:00'))
-    except:
+    except ValueError:
         return False
     return True

--- a/incognia/models.py
+++ b/incognia/models.py
@@ -1,5 +1,6 @@
 from typing import TypedDict, Literal
 
+
 class Coordinates(TypedDict):
     lat: float
     lng: float
@@ -41,6 +42,7 @@ class PaymentMethod(TypedDict, total=False):
     type: Literal['credit', 'debit']
     credit_card_info: CardInfo
     debit_card_info: CardInfo
+
 
 class Location(TypedDict, total=False):
     latitude: float

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -496,20 +496,14 @@ class TestIncogniaAPI(TestCase):
                                                   params=self.DEFAULT_PARAMS,
                                                   data=self.REGISTER_INVALID_WEB_LOGIN_DATA)
 
-
-# faltando lat, faltando loc, iso não respeitada
-# tanto em login quanto payment
     @patch.object(BaseRequest, 'post')
     @patch.object(TokenManager, 'get', return_value=TOKEN_VALUES)
     def test_register_login_with_valid_location_should_work(
             self, mock_token_manager_get: Mock, mock_base_request_post: Mock):
 
         mock_base_request_post.configure_mock(return_value=self.JSON_RESPONSE)
-        #mock_base_request_post.return_value = self.JSON_RESPONSE
 
         api = IncogniaAPI(self.CLIENT_ID, self.CLIENT_SECRET)
-
-        #print(inspect.signature(IncogniaAPI.register_login))
 
         request_response = api.register_login(self.REQUEST_TOKEN,
                                               self.ACCOUNT_ID,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -527,11 +527,13 @@ class TestIncogniaAPI(TestCase):
 
         api = IncogniaAPI(self.CLIENT_ID, self.CLIENT_SECRET)
 
-        self.assertRaises(IncogniaError, api.register_login,
-                        self.REQUEST_TOKEN,
-                        self.ACCOUNT_ID,
-                        location=self.INVALID_LOCATION_EMPTY_LATITUDE,
-                        policy_id=self.POLICY_ID)
+        self.assertRaises(
+            IncogniaError, api.register_login,
+            self.REQUEST_TOKEN,
+            self.ACCOUNT_ID,
+            location=self.INVALID_LOCATION_EMPTY_LATITUDE,
+            policy_id=self.POLICY_ID,
+            )
 
         mock_token_manager_get.assert_not_called()
         mock_base_request_post.assert_not_called()
@@ -545,15 +547,18 @@ class TestIncogniaAPI(TestCase):
 
         api = IncogniaAPI(self.CLIENT_ID, self.CLIENT_SECRET)
 
-        self.assertRaises(IncogniaError, api.register_login,
-                        self.REQUEST_TOKEN,
-                        self.ACCOUNT_ID,
-                        location=self.INVALID_LOCATION_EMPTY_LONGITUDE,
-                        policy_id=self.POLICY_ID)
+        self.assertRaises(
+            IncogniaError,
+            api.register_login,
+            self.REQUEST_TOKEN,
+            self.ACCOUNT_ID,
+            location=self.INVALID_LOCATION_EMPTY_LONGITUDE,
+            policy_id=self.POLICY_ID,
+            )
 
         mock_token_manager_get.assert_not_called()
         mock_base_request_post.assert_not_called()
-    
+
     @patch.object(BaseRequest, 'post')
     @patch.object(TokenManager, 'get', return_value=TOKEN_VALUES)
     def test_register_login_with_location_and_wrong_timestamp_should_raise_an_IncogniaError(
@@ -563,15 +568,17 @@ class TestIncogniaAPI(TestCase):
 
         api = IncogniaAPI(self.CLIENT_ID, self.CLIENT_SECRET)
 
-        self.assertRaises(IncogniaError, api.register_login,
-                        self.REQUEST_TOKEN,
-                        self.ACCOUNT_ID,
-                        location=self.INVALID_LOCATION_WRONG_TIMESTAMP,
-                        policy_id=self.POLICY_ID)
+        self.assertRaises(
+            IncogniaError,
+            api.register_login,
+            self.REQUEST_TOKEN,
+            self.ACCOUNT_ID,
+            location=self.INVALID_LOCATION_WRONG_TIMESTAMP,
+            policy_id=self.POLICY_ID,
+            )
 
         mock_token_manager_get.assert_not_called()
         mock_base_request_post.assert_not_called()
-
 
     @patch.object(BaseRequest, 'post')
     @patch.object(TokenManager, 'get', return_value=TOKEN_VALUES)
@@ -582,16 +589,20 @@ class TestIncogniaAPI(TestCase):
 
         api = IncogniaAPI(self.CLIENT_ID, self.CLIENT_SECRET)
 
-        request_response = api.register_payment(self.REQUEST_TOKEN,
-                                              self.ACCOUNT_ID,
-                                              location=self.LOCATION,
-                                              policy_id=self.POLICY_ID)
+        request_response = api.register_payment(
+            self.REQUEST_TOKEN,
+            self.ACCOUNT_ID,
+            location=self.LOCATION,
+            policy_id=self.POLICY_ID,
+            )
 
         mock_token_manager_get.assert_called()
-        mock_base_request_post.assert_called_with(Endpoints.TRANSACTIONS,
-                                                  headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
-                                                  params=self.DEFAULT_PARAMS,
-                                                  data=self.REGISTER_VALID_PAYMENT_DATA_WITH_LOCATION)
+        mock_base_request_post.assert_called_with(
+            Endpoints.TRANSACTIONS,
+            headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
+            params=self.DEFAULT_PARAMS,
+            data=self.REGISTER_VALID_PAYMENT_DATA_WITH_LOCATION,
+            )
 
         self.assertEqual(request_response, self.JSON_RESPONSE)
 
@@ -604,11 +615,13 @@ class TestIncogniaAPI(TestCase):
 
         api = IncogniaAPI(self.CLIENT_ID, self.CLIENT_SECRET)
 
-        self.assertRaises(IncogniaError, api.register_payment,
-                        self.REQUEST_TOKEN,
-                        self.ACCOUNT_ID,
-                        location=self.INVALID_LOCATION_EMPTY_LATITUDE,
-                        policy_id=self.POLICY_ID)
+        self.assertRaises(
+            IncogniaError, api.register_payment,
+            self.REQUEST_TOKEN,
+            self.ACCOUNT_ID,
+            location=self.INVALID_LOCATION_EMPTY_LATITUDE,
+            policy_id=self.POLICY_ID,
+            )
 
         mock_token_manager_get.assert_not_called()
         mock_base_request_post.assert_not_called()
@@ -622,15 +635,17 @@ class TestIncogniaAPI(TestCase):
 
         api = IncogniaAPI(self.CLIENT_ID, self.CLIENT_SECRET)
 
-        self.assertRaises(IncogniaError, api.register_payment,
-                        self.REQUEST_TOKEN,
-                        self.ACCOUNT_ID,
-                        location=self.INVALID_LOCATION_EMPTY_LONGITUDE,
-                        policy_id=self.POLICY_ID)
+        self.assertRaises(
+            IncogniaError, api.register_payment,
+            self.REQUEST_TOKEN,
+            self.ACCOUNT_ID,
+            location=self.INVALID_LOCATION_EMPTY_LONGITUDE,
+            policy_id=self.POLICY_ID,
+            )
 
         mock_token_manager_get.assert_not_called()
         mock_base_request_post.assert_not_called()
-    
+
     @patch.object(BaseRequest, 'post')
     @patch.object(TokenManager, 'get', return_value=TOKEN_VALUES)
     def test_register_payment_with_location_and_wrong_timestamp_should_raise_an_IncogniaError(
@@ -640,11 +655,14 @@ class TestIncogniaAPI(TestCase):
 
         api = IncogniaAPI(self.CLIENT_ID, self.CLIENT_SECRET)
 
-        self.assertRaises(IncogniaError, api.register_payment,
-                        self.REQUEST_TOKEN,
-                        self.ACCOUNT_ID,
-                        location=self.INVALID_LOCATION_WRONG_TIMESTAMP,
-                        policy_id=self.POLICY_ID)
+        self.assertRaises(
+            IncogniaError,
+            api.register_payment,
+            self.REQUEST_TOKEN,
+            self.ACCOUNT_ID,
+            location=self.INVALID_LOCATION_WRONG_TIMESTAMP,
+            policy_id=self.POLICY_ID,
+            )
 
         mock_token_manager_get.assert_not_called()
         mock_base_request_post.assert_not_called()


### PR DESCRIPTION
## Proposed changes
This PR adds an optional location parameter to the functions used for registering logins and payments.

## Further comments

Requests to the /transactions endpoint may include a location field (lat, long, time of collection). However, there was no corresponding field in the Python wrapper before. 

**The previous PR had issues with the flake8 style checks, which have since been resolved.**

Checklist
[x] Style check and tests pass locally with my changes
[x] I have added tests that prove my fix is effective or that my feature works