### PR TITLE
feat: adds web signup function

### DIFF
--- a/incognia/api.py
+++ b/incognia/api.py
@@ -60,6 +60,30 @@ class IncogniaAPI(metaclass=Singleton):
         except IncogniaHTTPError as e:
             raise IncogniaHTTPError(e) from None
 
+    def register_new_web_signup(self,
+                                request_token: Optional[str],
+                                policy_id: Optional[str] = None,
+                                account_id: Optional[str] = None,
+                                custom_properties: Optional[dict] = None,
+                                ) -> dict:
+        if not request_token:
+            raise IncogniaError('request_token is required.')
+
+        try:
+            headers = self.__get_authorization_header()
+            headers.update(JSON_CONTENT_HEADER)
+            body = {
+                'request_token': request_token,
+                'policy_id': policy_id,
+                'account_id': account_id,
+                'custom_properties': custom_properties
+            }
+            data = encode(body)
+            return self.__request.post(Endpoints.SIGNUPS, headers=headers, data=data)
+
+        except IncogniaHTTPError as e:
+            raise IncogniaHTTPError(e) from None
+
     def register_feedback(self,
                           event: str,
                           external_id: Optional[str] = None,


### PR DESCRIPTION
## Proposed changes
This commit adds a `register_new_web_signup` function.

## Additional context

- In terms of functionality, this PR allows users to pass a `custom_properties` object in the signup request.
- Additionally, it creates a semantic distiction between mobile and web signups
- A similar function is present in the Java API library and this PR will also help maintain consistency across our libs.

## Checklist
- [x] Style check and tests pass locally with my changes, as well as on identical workflow on forked repository
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the updated request signature works on the live API endpoint