### PR TITLE
Chore/add payment methods

### DIFF
--- a/incognia/models.py
+++ b/incognia/models.py
@@ -39,7 +39,9 @@ class CardInfo(TypedDict, total=False):
 
 
 class PaymentMethod(TypedDict, total=False):
-    type: Literal['credit', 'debit']
+    type: Literal['account_balance', 'apple_pay', 'bancolombia',
+                  'boleto_bancario', 'cash', 'credit', 'debit',
+                  'google_pay', 'meal_voucher', 'nu_pay', 'paypal', 'pix']
     credit_card_info: CardInfo
     debit_card_info: CardInfo
 

--- a/incognia/models.py
+++ b/incognia/models.py
@@ -40,7 +40,7 @@ class CardInfo(TypedDict, total=False):
 
 class PaymentMethod(TypedDict, total=False):
     type: Literal['account_balance', 'apple_pay', 'bancolombia',
-                  'boleto_bancario', 'cash', 'credit', 'debit',
+                  'boleto_bancario', 'cash', 'credit_card', 'debit_card',
                   'google_pay', 'meal_voucher', 'nu_pay', 'paypal', 'pix']
     credit_card_info: CardInfo
     debit_card_info: CardInfo


### PR DESCRIPTION
## Proposed changes

This commit adds all missing payment types to the `PaymentMethod` class, e.g: `cash`, `pix`, `account_balance`, etc.

## Checklist
- [x] Style check and tests pass locally with my changes, as well as on identical workflow on forked repository