### PR TITLE
feat: adds register payments params

### DIFF
--- a/incognia/api.py
+++ b/incognia/api.py
@@ -12,6 +12,7 @@ from .models import (
     PaymentValue,
     PaymentMethod,
     Location,
+    Coupon,
 )
 from .singleton import Singleton
 from .token_manager import TokenManager
@@ -134,7 +135,12 @@ class IncogniaAPI(metaclass=Singleton):
                          payment_value: Optional[PaymentValue] = None,
                          payment_methods: Optional[List[PaymentMethod]] = None,
                          evaluate: Optional[bool] = None,
-                         policy_id: Optional[str] = None) -> dict:
+                         policy_id: Optional[str] = None,
+                         custom_properties: Optional[dict] = None,
+                         coupon: Optional[Coupon] = None,
+                         device_os: Optional[str] = None,
+                         app_version: Optional[str] = None,
+                         store_id: Optional[str] = None) -> dict:
         if not request_token:
             raise IncogniaError('request_token is required.')
         if not account_id:
@@ -163,7 +169,12 @@ class IncogniaAPI(metaclass=Singleton):
                 'addresses': addresses,
                 'payment_value': payment_value,
                 'payment_methods': payment_methods,
-                'policy_id': policy_id
+                'policy_id': policy_id,
+                'custom_properties': custom_properties,
+                'coupon': coupon,
+                'device_os': device_os.lower() if device_os is not None else None,
+                'app_version': app_version,
+                'store_id': store_id,
             }
             data = encode(body)
             return self.__request.post(Endpoints.TRANSACTIONS, headers=headers, params=params,

--- a/incognia/models.py
+++ b/incognia/models.py
@@ -20,6 +20,14 @@ class StructuredAddress(TypedDict, total=False):
     postal_code: str
 
 
+class Coupon (TypedDict, total=False):
+    type: Literal['percent_off', 'fixed_value']
+    value: float
+    max_discount: float
+    id: str
+    name: str
+
+
 class TransactionAddress(TypedDict, total=False):
     type: Literal['shipping', 'billing', 'home']
     structured_address: StructuredAddress


### PR DESCRIPTION
## Proposed changes

This commit adds the following parameters to the `register_payment` function.

- `custom_properties`
- `coupon`
- `app_version`
- `device_os`
- `store_id`

## Additional context

The `store_id` parameter is documented in the API reference , but not in the developer docs.
In live API tests, adding this field raises no errors, but I'm unsure if the field is ever processed or just ignored.

## Checklist

- [x] Style check and tests pass locally with my changes, as well as on identical workflow on forked repository
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested the updated request signature works on the live API endpoint