### PR TITLE
feat: adds person_id across all API request helper functions

### DIFF
--- a/incognia/api.py
+++ b/incognia/api.py
@@ -13,6 +13,7 @@ from .models import (
     PaymentMethod,
     Location,
     Coupon,
+    PersonID,
 )
 from .singleton import Singleton
 from .token_manager import TokenManager
@@ -37,7 +38,8 @@ class IncogniaAPI(metaclass=Singleton):
                             policy_id: Optional[str] = None,
                             account_id: Optional[str] = None,
                             device_os: Optional[str] = None,
-                            app_version: Optional[str] = None) -> dict:
+                            app_version: Optional[str] = None,
+                            person_id: Optional[PersonID] = None) -> dict:
         if not request_token:
             raise IncogniaError('request_token is required.')
 
@@ -53,7 +55,8 @@ class IncogniaAPI(metaclass=Singleton):
                 'policy_id': policy_id,
                 'account_id': account_id,
                 'device_os': device_os.lower() if device_os is not None else None,
-                'app_version': app_version
+                'app_version': app_version,
+                'person_id': person_id,
             }
             data = encode(body)
             return self.__request.post(Endpoints.SIGNUPS, headers=headers, data=data)
@@ -66,7 +69,7 @@ class IncogniaAPI(metaclass=Singleton):
                                 policy_id: Optional[str] = None,
                                 account_id: Optional[str] = None,
                                 custom_properties: Optional[dict] = None,
-                                ) -> dict:
+                                person_id: Optional[PersonID] = None) -> dict:
         if not request_token:
             raise IncogniaError('request_token is required.')
 
@@ -77,7 +80,8 @@ class IncogniaAPI(metaclass=Singleton):
                 'request_token': request_token,
                 'policy_id': policy_id,
                 'account_id': account_id,
-                'custom_properties': custom_properties
+                'custom_properties': custom_properties,
+                'person_id': person_id,
             }
             data = encode(body)
             return self.__request.post(Endpoints.SIGNUPS, headers=headers, data=data)
@@ -95,7 +99,8 @@ class IncogniaAPI(metaclass=Singleton):
                           installation_id: Optional[str] = None,
                           request_token: Optional[str] = None,
                           occurred_at: dt.datetime = None,
-                          expires_at: dt.datetime = None) -> None:
+                          expires_at: dt.datetime = None,
+                          person_id: Optional[PersonID] = None) -> None:
         if not event:
             raise IncogniaError('event is required.')
         if occurred_at is not None and not has_timezone(occurred_at):
@@ -114,7 +119,8 @@ class IncogniaAPI(metaclass=Singleton):
                 'signup_id': signup_id,
                 'account_id': account_id,
                 'installation_id': installation_id,
-                'request_token': request_token
+                'request_token': request_token,
+                'person_id': person_id,
             }
             if occurred_at is not None:
                 body['occurred_at'] = occurred_at.isoformat()
@@ -140,7 +146,8 @@ class IncogniaAPI(metaclass=Singleton):
                          coupon: Optional[Coupon] = None,
                          device_os: Optional[str] = None,
                          app_version: Optional[str] = None,
-                         store_id: Optional[str] = None) -> dict:
+                         store_id: Optional[str] = None,
+                         person_id: Optional[PersonID] = None) -> dict:
         if not request_token:
             raise IncogniaError('request_token is required.')
         if not account_id:
@@ -175,6 +182,7 @@ class IncogniaAPI(metaclass=Singleton):
                 'device_os': device_os.lower() if device_os is not None else None,
                 'app_version': app_version,
                 'store_id': store_id,
+                'person_id': person_id,
             }
             data = encode(body)
             return self.__request.post(Endpoints.TRANSACTIONS, headers=headers, params=params,
@@ -191,7 +199,8 @@ class IncogniaAPI(metaclass=Singleton):
                        evaluate: Optional[bool] = None,
                        policy_id: Optional[str] = None,
                        device_os: Optional[str] = None,
-                       app_version: Optional[str] = None) -> dict:
+                       app_version: Optional[str] = None,
+                       person_id: Optional[PersonID] = None) -> dict:
         if not request_token:
             raise IncogniaError('request_token is required.')
         if not account_id:
@@ -220,6 +229,7 @@ class IncogniaAPI(metaclass=Singleton):
                 'policy_id': policy_id,
                 'device_os': device_os.lower() if device_os is not None else None,
                 'app_version': app_version,
+                'person_id': person_id,
             }
             data = encode(body)
             return self.__request.post(Endpoints.TRANSACTIONS, headers=headers, params=params,
@@ -234,7 +244,8 @@ class IncogniaAPI(metaclass=Singleton):
                            external_id: Optional[str] = None,
                            evaluate: Optional[bool] = None,
                            policy_id: Optional[str] = None,
-                           custom_properties: Optional[dict] = None) -> dict:
+                           custom_properties: Optional[dict] = None,
+                           person_id: Optional[PersonID] = None) -> dict:
         if not request_token:
             raise IncogniaError('request_token is required.')
         if not account_id:
@@ -251,6 +262,7 @@ class IncogniaAPI(metaclass=Singleton):
                 'external_id': external_id,
                 'policy_id': policy_id,
                 'custom_properties': custom_properties,
+                'person_id': person_id,
             }
             data = encode(body)
             return self.__request.post(Endpoints.TRANSACTIONS, headers=headers, params=params,

--- a/incognia/models.py
+++ b/incognia/models.py
@@ -58,3 +58,8 @@ class Location(TypedDict, total=False):
     latitude: float
     longitude: float
     collected_at: str
+
+
+class PersonID(TypedDict, total=False):
+    type: str
+    value: str

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,6 +22,10 @@ class TestIncogniaAPI(TestCase):
     ADDRESS_LINE: Final[str] = 'ANY_ADDRESS_LINE'
     DEVICE_OS: Final[str] = 'ANY_DEVICE_OS'
     APP_VERSION: Final[str] = 'ANY_APP_VERSION'
+    PERSON_ID: Final[dict] = {
+        'type': 'cpf',
+        'value': '12345678901'
+    }
     STRUCTURED_ADDRESS: Final[dict] = {
         'locale': 'ANY_LOCALE',
         'country_name': 'ANY_COUNTRY_NAME',
@@ -71,7 +75,8 @@ class TestIncogniaAPI(TestCase):
         'policy_id': f'{POLICY_ID}',
         'account_id': f'{ACCOUNT_ID}',
         'device_os': f'{DEVICE_OS.lower()}',
-        'app_version': f'{APP_VERSION}'
+        'app_version': f'{APP_VERSION}',
+        'person_id': PERSON_ID
     })
     CUSTOM_PROPERTIES: Final[dict] = {
         'float_field': 6.092,
@@ -87,7 +92,8 @@ class TestIncogniaAPI(TestCase):
         'request_token': f'{REQUEST_TOKEN}',
         'policy_id': f'{POLICY_ID}',
         'account_id': f'{ACCOUNT_ID}',
-        'custom_properties': CUSTOM_PROPERTIES
+        'custom_properties': CUSTOM_PROPERTIES,
+        'person_id': PERSON_ID
     })
     OK_STATUS_CODE: Final[int] = 200
     CLIENT_ERROR_CODE: Final[int] = 400
@@ -155,8 +161,9 @@ class TestIncogniaAPI(TestCase):
         'account_id': f'{ACCOUNT_ID}',
         'installation_id': f'{INSTALLATION_ID}',
         'request_token': f'{REQUEST_TOKEN}',
+        'person_id': PERSON_ID,
         'occurred_at': TIMESTAMP.isoformat(),
-        'expires_at': TIMESTAMP.isoformat(),
+        'expires_at': TIMESTAMP.isoformat()
     })
     REGISTER_VALID_PAYMENT_DATA: Final[bytes] = encode({
         'type': 'payment',
@@ -178,7 +185,8 @@ class TestIncogniaAPI(TestCase):
         'coupon': COUPON,
         'device_os': f'{DEVICE_OS.lower()}',
         'app_version': f'{APP_VERSION}',
-        'store_id': f'{STORE_ID}'
+        'store_id': f'{STORE_ID}',
+        'person_id': PERSON_ID
     })
     REGISTER_VALID_PAYMENT_DATA_WITH_LOCATION: Final[bytes] = encode({
         'type': 'payment',
@@ -213,7 +221,8 @@ class TestIncogniaAPI(TestCase):
         'external_id': f'{EXTERNAL_ID}',
         'policy_id': f'{POLICY_ID}',
         'device_os': f'{DEVICE_OS.lower()}',
-        'app_version': f'{APP_VERSION}'
+        'app_version': f'{APP_VERSION}',
+        'person_id': PERSON_ID
     })
     REGISTER_VALID_WEB_LOGIN_DATA: Final[bytes] = encode({
         'type': 'login',
@@ -227,7 +236,8 @@ class TestIncogniaAPI(TestCase):
         'account_id': f'{ACCOUNT_ID}',
         'external_id': f'{EXTERNAL_ID}',
         'policy_id': f'{POLICY_ID}',
-        'custom_properties': CUSTOM_PROPERTIES
+        'custom_properties': CUSTOM_PROPERTIES,
+        'person_id': PERSON_ID
     })
     REGISTER_INVALID_LOGIN_DATA: Final[bytes] = encode({
         'type': 'login',
@@ -294,7 +304,8 @@ class TestIncogniaAPI(TestCase):
                                            account_id=self.ACCOUNT_ID,
                                            request_token=self.REQUEST_TOKEN,
                                            device_os=self.DEVICE_OS,
-                                           app_version=self.APP_VERSION)
+                                           app_version=self.APP_VERSION,
+                                           person_id=self.PERSON_ID)
 
         mock_token_manager_get.assert_called()
         mock_base_request_post.assert_called_with(Endpoints.SIGNUPS,
@@ -313,7 +324,8 @@ class TestIncogniaAPI(TestCase):
         response = api.register_new_web_signup(request_token=self.REQUEST_TOKEN,
                                                policy_id=self.POLICY_ID,
                                                account_id=self.ACCOUNT_ID,
-                                               custom_properties=self.CUSTOM_PROPERTIES)
+                                               custom_properties=self.CUSTOM_PROPERTIES,
+                                               person_id=self.PERSON_ID)
 
         mock_token_manager_get.assert_called()
         mock_base_request_post.assert_called_with(Endpoints.SIGNUPS,
@@ -403,7 +415,8 @@ class TestIncogniaAPI(TestCase):
                               signup_id=self.SIGNUP_ID,
                               account_id=self.ACCOUNT_ID,
                               installation_id=self.INSTALLATION_ID,
-                              request_token=self.REQUEST_TOKEN)
+                              request_token=self.REQUEST_TOKEN,
+                              person_id=self.PERSON_ID)
 
         mock_token_manager_get.assert_called()
         mock_base_request_post.assert_called_with(Endpoints.FEEDBACKS,
@@ -490,7 +503,8 @@ class TestIncogniaAPI(TestCase):
             coupon=self.COUPON,
             device_os=self.DEVICE_OS,
             app_version=self.APP_VERSION,
-            store_id=self.STORE_ID
+            store_id=self.STORE_ID,
+            person_id=self.PERSON_ID
         )
 
         mock_token_manager_get.assert_called()
@@ -641,7 +655,8 @@ class TestIncogniaAPI(TestCase):
                                                   self.ACCOUNT_ID,
                                                   external_id=self.EXTERNAL_ID,
                                                   policy_id=self.POLICY_ID,
-                                                  custom_properties=self.CUSTOM_PROPERTIES)
+                                                  custom_properties=self.CUSTOM_PROPERTIES,
+                                                  person_id=self.PERSON_ID)
         mock_token_manager_get.assert_called()
         mock_base_request_post.assert_called_with(Endpoints.TRANSACTIONS,
                                                   headers=self.AUTH_AND_JSON_CONTENT_HEADERS,
@@ -731,7 +746,8 @@ class TestIncogniaAPI(TestCase):
                                               external_id=self.EXTERNAL_ID,
                                               policy_id=self.POLICY_ID,
                                               device_os=self.DEVICE_OS,
-                                              app_version=self.APP_VERSION)
+                                              app_version=self.APP_VERSION,
+                                              person_id=self.PERSON_ID)
 
         mock_token_manager_get.assert_called()
         mock_base_request_post.assert_called_with(Endpoints.TRANSACTIONS,


### PR DESCRIPTION
## Proposed changes

Adds optional `person_id` field to the following methods:
* `register_new_signup`
* `register_new_web_signup`
* `register_login`
* `register_web_login`
* `register_payment`
* `register_feedback`


## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested on the live API endpoint