### PR TITLE
feat: adds debtor and creditor account parameters

### DIFF
--- a/incognia/api.py
+++ b/incognia/api.py
@@ -14,6 +14,7 @@ from .models import (
     Location,
     Coupon,
     PersonID,
+    BankAccountInfo,
 )
 from .singleton import Singleton
 from .token_manager import TokenManager
@@ -149,7 +150,9 @@ class IncogniaAPI(metaclass=Singleton):
                          device_os: Optional[str] = None,
                          app_version: Optional[str] = None,
                          store_id: Optional[str] = None,
-                         person_id: Optional[PersonID] = None) -> dict:
+                         person_id: Optional[PersonID] = None,
+                         debtor_account: Optional[BankAccountInfo] = None,
+                         creditor_account: Optional[BankAccountInfo] = None) -> dict:
         if not request_token:
             raise IncogniaError('request_token is required.')
         if not account_id:
@@ -185,6 +188,8 @@ class IncogniaAPI(metaclass=Singleton):
                 'app_version': app_version,
                 'store_id': store_id,
                 'person_id': person_id,
+                'debtor_account': debtor_account,
+                'creditor_account': creditor_account,
             }
             data = encode(body)
             return self.__request.post(Endpoints.TRANSACTIONS, headers=headers, params=params,

--- a/incognia/models.py
+++ b/incognia/models.py
@@ -1,4 +1,4 @@
-from typing import TypedDict, Literal
+from typing import TypedDict, Literal, List
 
 
 class Coordinates(TypedDict):
@@ -63,3 +63,21 @@ class Location(TypedDict, total=False):
 class PersonID(TypedDict, total=False):
     type: str
     value: str
+
+
+class PixKey(TypedDict):
+    type: str
+    value: str
+
+
+class BankAccountInfo(TypedDict, total=False):
+    account_type: str
+    account_purpose: str
+    holder_type: str
+    holder_tax_id: PersonID
+    country: str
+    ispb_code: str
+    branch_code: str
+    account_number: str
+    account_check_digit: str
+    pix_keys: List[PixKey]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -150,6 +150,24 @@ class TestIncogniaAPI(TestCase):
         'longitude': 13.123,
         'collected_at': "12:04 14/10/2024"
     }
+    BANK_ACCOUNT_INFO: Final[dict] = {
+        "account_type": "checking",
+        "account_purpose": "personal",
+        "holder_type": "individual",
+        "holder_tax_id": {
+            "type": "cpf",
+            "value": "12345678900",
+        },
+        "country": "BR",
+        "ispb_code": "12345678",
+        "branch_code": "0001",
+        "account_number": "987654",
+        "account_check_digit": "0",
+        "pix_keys": [
+            {"type": "email", "value": "user@example.com"},
+            {"type": "phone", "value": "+5511999999999"},
+        ],
+    }
     REGISTER_VALID_FEEDBACK_DATA: Final[bytes] = encode({
         'event': f'{VALID_EVENT_FEEDBACK_TYPE}'
     })
@@ -187,7 +205,9 @@ class TestIncogniaAPI(TestCase):
         'device_os': f'{DEVICE_OS.lower()}',
         'app_version': f'{APP_VERSION}',
         'store_id': f'{STORE_ID}',
-        'person_id': PERSON_ID
+        'person_id': PERSON_ID,
+        'debtor_account': BANK_ACCOUNT_INFO,
+        'creditor_account': BANK_ACCOUNT_INFO
     })
     REGISTER_VALID_PAYMENT_DATA_WITH_LOCATION: Final[bytes] = encode({
         'type': 'payment',
@@ -506,7 +526,9 @@ class TestIncogniaAPI(TestCase):
             device_os=self.DEVICE_OS,
             app_version=self.APP_VERSION,
             store_id=self.STORE_ID,
-            person_id=self.PERSON_ID
+            person_id=self.PERSON_ID,
+            debtor_account=self.BANK_ACCOUNT_INFO,
+            creditor_account=self.BANK_ACCOUNT_INFO
         )
 
         mock_token_manager_get.assert_called()


### PR DESCRIPTION
## Proposed changes

Adds `debtor_account` and `creditor_account` fields to the `register_payment` method

## Checklist
- [x] Style check and tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested on the live API endpoint